### PR TITLE
Added eslint configuration and fixed most of linting errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,60 @@
+{
+    "extends": [
+        "eslint:recommended",
+        "airbnb"
+    ],
+    "rules": {
+        "indent": [
+            "error",
+            4,
+            {
+                "SwitchCase": 1
+            }
+        ],
+        "react/jsx-indent": [
+            "error",
+            4
+        ],
+        "react/jsx-indent-props": [
+            "error",
+            4
+        ],
+        "quotes": [
+            "error",
+            "single"
+        ],
+        "linebreak-style": "off",
+        "arrow-parens": [
+            "error",
+            "as-needed"
+        ],
+        "arrow-body-style": [
+            "error",
+            "as-needed"
+        ],
+        "strict": "off",
+        "no-console": "off",
+        "valid-jsdoc": 2,
+        "import/no-extraneous-dependencies": 0,
+        "import/no-unresolved": [
+            "error",
+            {
+                "ignore": [ "nrfconnect/.*", "pc-ble-driver-js", "pc-nrfjprog-js", "serialport", "electron" ]
+            }
+        ],
+        "import/extensions": ["off"]
+    },
+    "no-undef": 1,
+    "no-unused-vars": 1,
+    "plugins": [
+        "react",
+        "import"
+    ],
+    "env": {
+        "es6": true,
+        "browser": true,
+        "node": true,
+        "jasmine": true,
+        "jest": true
+    }
+}

--- a/class-diagram.txt
+++ b/class-diagram.txt
@@ -11,17 +11,17 @@
 [DfuOperation|progressGenerator:Generator readonly|constructor(dfuUpdates dfuTransport autoStart);start(noContinue)]
 
 
-[DfuAbstractTransport|progressGenerator:Generator readonly|sendInitPacket(bytes); sendFirmwareImage(bytes); _createObject(type size); _writeObject(req reqLength); _crcObject(); _executeObject(); _selectObject(type); _updateProgress(bytes)]
+[DfuAbstractTransport|progressGenerator:Generator readonly|sendInitPacket(bytes); sendFirmwareImage(bytes); createObject(type size); writeObject(req reqLength); crcObject(); executeObject(); selectObject(type); updateProgress(bytes)]
 
 [note:A transport must define the 5 private methods. They map to the nRF SDK's 'DFU request operations'. A specific transport might do additional logic. i.e. splitting the writeObject request into smaller wire packets and checking CRCs for them.]-[DfuAbstractTransport]
 
-[note:The abstract transport implements the logic to split a init packet or a firmware image into 1KiB or 4KiB chunks (as per the _selectObject() return values) and perform several calls to _writeObject().]-[DfuAbstractTransport]
+[note:The abstract transport implements the logic to split a init packet or a firmware image into 1KiB or 4KiB chunks (as per the selectObject() return values) and perform several calls to writeObject().]-[DfuAbstractTransport]
 
 
 
 [DfuOperation]++-[DfuUpdates]
 [DfuOperation]++-[DfuAbstractTransport]
-[DfuAbstractTransport]^-[DfuTransportPrn||_writeCommand(bytes);_writeData(bytes);_read();_onData;_ready();_parse();_assertPacket();_writeObjectPiece()]
+[DfuAbstractTransport]^-[DfuTransportPrn||writeCommand(bytes);writeData(bytes);read();onData;ready();parse();assertPacket();writeObjectPiece()]
 [DfuAbstractTransport]^-[DfuSinkTransport]
 [DfuTransportPrn]^-[DfuTransportSerial]
 [DfuTransportPrn]^-[DfuTransportNoble]
@@ -39,11 +39,7 @@
 [note:There is also a use case for performing DFU over a nRF cloud gateway. Let's put that into the 'crazy ideas' pile for now.]
 
 
-[ProgressCounter|nextProgressUpdate:readonly;_current;_target|constructor(targetAmount);advance(amount)]
+[ProgressCounter|nextProgressUpdate:readonly;current;target|constructor(targetAmount);advance(amount)]
 
 [DfuOperation]++-[ProgressCounter]
 [DfuAbstractTransport]++-[ProgressCounter]
-
-
-
-

--- a/manual-tests/noble-1.js
+++ b/manual-tests/noble-1.js
@@ -35,10 +35,10 @@ noble.on('discover', function(peripheral) {
         
         let nobleTransport = new nrfDfu.DfuTransportNoble(peripheral, 1);
         
-//         nobleTransport._ready().then(()=>{
-//             nobleTransport._writeCommand(new Uint8Array([0x06, 0x02]));
+//         nobleTransport.ready().then(()=>{
+//             nobleTransport.writeCommand(new Uint8Array([0x06, 0x02]));
 //             
-//             nobleTransport._read().then((bytes)=>{
+//             nobleTransport.read().then((bytes)=>{
 //                 console.log('Received: ', bytes);
 //             });
 //         });

--- a/manual-tests/slip-1.js
+++ b/manual-tests/slip-1.js
@@ -108,12 +108,5 @@ SerialPort.list().then((ports)=>{
 //     });
 
 
-});
-
-
-
-
-
-
-
-
+})
+.catch(console.log);

--- a/manual-tests/slip-2.js
+++ b/manual-tests/slip-2.js
@@ -54,12 +54,5 @@ Promise.all([
     .then(()=>{
         port.close();
     });
-});
-
-
-
-
-
-
-
-
+})
+.catch(console.log);

--- a/manual-tests/slip-3.js
+++ b/manual-tests/slip-3.js
@@ -64,12 +64,5 @@ Promise.all([
     .then(()=>{
         port.close();
     });
-});
-
-
-
-
-
-
-
-
+})
+.catch(console.log);

--- a/manual-tests/version-command.js
+++ b/manual-tests/version-command.js
@@ -1,39 +1,30 @@
 // This is just a manual test
 
-let nrfDfu = require('../dist/nrf-dfu.cjs');
+const nrfDfu = require('../dist/nrf-dfu.cjs');
 
-let SerialPort = require('serialport');
+const SerialPort = require('serialport');
 
+SerialPort.list().then(ports => {
+    ports.forEach(port => {
+        console.log(`${port.vendorId}/${port.productId}`);
+    });
+    console.log('Scanned');
+    const filteredPorts = ports.filter(port => (
+        (port.vendorId === '1915' && port.productId === '521F') || // NordicSemi default USB SDFU, win
+        (port.vendorId === '1915' && port.productId === 'nRF52 USB SDFU') // NordicSemi default USB SDFU, linux
+    ));
 
-Promise.all([
-    SerialPort.list().then((ports)=>{
-
-
-        ports.forEach(port=>{
-            console.log(port.vendorId + '/' + port.productId);
-        })
-        console.log('Scanned');
-        ports = ports.filter(port=>(
-            (port.vendorId === '1915' && port.productId === '521F') || // NordicSemi default USB SDFU, win
-            (port.vendorId === '1915' && port.productId === 'nRF52 USB SDFU') // NordicSemi default USB SDFU, linux
-        ));
-
-        if (ports && ports[0]) {
-            console.log(ports[0]);
-            return new SerialPort(ports[0].comName, { baudRate: 115200, autoOpen: false});
-        } else {
-            throw new Error('No serial ports with a Segger are available');
-        }
-
-    }),
-    nrfDfu.DfuUpdates.fromZipFilePath('./spec/test-data/blinky_s140.zip')
-])
-.then(([port, updates])=>{
-
-    let serialTransport = new nrfDfu.DfuTransportSerial(port, 0);
+    if (filteredPorts && filteredPorts[0]) {
+        console.log(filteredPorts[0]);
+        return new SerialPort(filteredPorts[0].comName, { baudRate: 115200, autoOpen: false });
+    }
+    throw new Error('No serial ports with a Segger are available');
+})
+.then(port => {
+    const serialTransport = new nrfDfu.DfuTransportSerial(port, 0);
 
     serialTransport.getFirmwareVersion()
-    .then(res => {
-        console.log(res);
-    });
-});
+    .then(console.log)
+    .then(() => port.close());
+})
+.catch(console.log);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "private": true,
   "scripts": {
     "rollup": "rollup -c rollup.config.js",
-    "test": "rollup -c rollup.config.js; jasmine"
+    "test": "rollup -c rollup.config.js; jasmine",
+    "lint": "eslint src/"
   },
   "dependencies": {
     "crc": "git+https://github.com/IvanSanchez/node-crc.git#no-buffer",
@@ -19,10 +20,18 @@
     "slip": "git+https://github.com/IvanSanchez/slip.js.git"
   },
   "devDependencies": {
+    "babel-core": "^6.26.0",
     "debug": "^3.1.0",
+    "eslint": "3.19.0",
+    "eslint-config-airbnb": "15.0.0",
+    "eslint-loader": "1.7.1",
+    "eslint-plugin-import": "2.2.0",
+    "eslint-plugin-jsx-a11y": "5.0.1",
+    "eslint-plugin-react": "7.0.1",
     "jasmine": "^2.8.0",
     "noble": "^1.8.1",
     "rollup": "^0.50.0",
+    "rollup-plugin-babel": "^3.0.3",
     "rollup-plugin-commonjs": "^8.2.1",
     "rollup-plugin-node-builtins": "^2.1.2",
     "rollup-plugin-node-globals": "^1.1.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,6 +3,7 @@ import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 import builtins from 'rollup-plugin-node-builtins';
 import globals from 'rollup-plugin-node-globals';
+import babel from 'rollup-plugin-babel';
 import pkg from './package.json';
 
 export default [
@@ -21,6 +22,9 @@ export default [
         name: 'nrfDfu',
         plugins: [
             resolve(), // so Rollup can find `crc32`
+            babel({
+                exclude: 'node_modules/**'
+            }),
             commonjs(),
             builtins(),
             globals()
@@ -41,6 +45,9 @@ export default [
         ],
         plugins: [
             resolve(), // so Rollup can find `crc32`
+            babel({
+                exclude: 'node_modules/**'
+            })
 // 			commonjs() // so Rollup can convert `crc32` to an ES module
         ]
     }

--- a/src/DfuOperation.js
+++ b/src/DfuOperation.js
@@ -1,8 +1,4 @@
-
-import ProgressCounter from './ProgressCounter';
-
-const debug = require('debug')('dfu:operation');
-
+// import ProgressCounter from './ProgressCounter';
 
 /**
  * Represents a DFU Operation - the act of updating the firmware on a
@@ -22,18 +18,20 @@ const debug = require('debug')('dfu:operation');
  */
 export default class DfuOperation {
 
-    constructor(dfuUpdates, dfuTransport, autoStart=false) {
-        this._updates = dfuUpdates.updates;
-        this._updatesPerformed = 0;
-        this._transport = dfuTransport;
+    constructor(dfuUpdates, dfuTransport, autoStart = false) {
+        this.updates = dfuUpdates.updates;
+        // this.updatesPerformed = 0;
+        this.transport = dfuTransport;
 
-//         let totalSize = this._updates.reduce((update)=>)
-//         this._progressCounter = new ProgressCounter(totalSize);
+//         let totalSize = this.updates.reduce((update)=>)
+//         this.progressCounter = new ProgressCounter(totalSize);
 
-        if (this.autoStart) { this.start(); }
+        if (autoStart) {
+            this.start();
+        }
     }
 
-    get progressGenerator() { return this._progressGenerator; }
+    // get progressGenerator() { return this._progressGenerator; }
 
     /**
      * Starts the DFU operation. Returns a Promise that resolves as soon as
@@ -47,15 +45,16 @@ export default class DfuOperation {
      *
      * Calling start() more than once has no effect, and will only return a
      * reference to the first Promise that was returned.
+     *
+     * @param {Bool} forceful if should skip the steps
+     * @return {Promise} a Promise that resolves as soon as the DFU has been performed
      */
     start(forceful = false) {
-        if (this._finishPromise) { return this._finishPromise; }
-
-        return this._finishPromise = this._start(forceful);
-    }
-
-    _start(forceful) {
-        return this._performNextUpdate(0, forceful);
+        if (this.finishPromise) {
+            return this.finishPromise;
+        }
+        this.finishPromise = this.performNextUpdate(0, forceful);
+        return this.finishPromise;
     }
 
     // Takes in an update from this._update, performs it. Returns a Promise
@@ -63,41 +62,23 @@ export default class DfuOperation {
     // - Tell the transport to send the init packet
     // - Tell the transport to send the binary blob
     // - Proceed to the next update
-    _performNextUpdate(updateNumber, forceful) {
-        if (this._updates.length <= updateNumber) {
+    performNextUpdate(updateNumber, forceful) {
+        if (this.updates.length <= updateNumber) {
             return Promise.resolve();
         }
 
         let start;
         if (forceful) {
-            start = this._transport.restart();
+            start = this.transport.restart();
         } else {
             start = Promise.resolve();
         }
 
         return start
-        .then(()=>{
-            return this._transport.sendInitPacket(this._updates[updateNumber].initPacket)
-        })
-        .then(()=>{
-            return this._transport.sendFirmwareImage(this._updates[updateNumber].firmwareImage)
-        })
-        .then(()=>{
-            this._performNextUpdate(updateNumber+1, forceful);
-        });
+        .then(() => this.transport.sendInitPacket(this.updates[updateNumber].initPacket))
+        .then(() => this.transport.sendFirmwareImage(this.updates[updateNumber].firmwareImage))
+        .then(() => this.performNextUpdate(updateNumber + 1, forceful));
     }
 
 
 }
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/DfuTransportPrn.js
+++ b/src/DfuTransportPrn.js
@@ -1,9 +1,9 @@
-
-import DfuAbstractTransport from './DfuAbstractTransport';
-const debug = require('debug')('dfu:prntransport');
-
 // FIXME: Should be `import {crc32} from 'crc'`, https://github.com/alexgorbatchev/node-crc/pull/50
 import crc32 from 'crc/src/crc32';
+
+import DfuAbstractTransport from './DfuAbstractTransport';
+
+const debug = require('debug')('dfu:prntransport');
 
 
 /**
@@ -24,88 +24,89 @@ export default class DfuTransportPrn extends DfuAbstractTransport {
         super();
 
         if (this.constructor === DfuTransportPrn) {
-            throw new Error("Cannot instantiate DfuTransportPrn, use a concrete subclass instead.");
+            throw new Error('Cannot instantiate DfuTransportPrn, use a concrete subclass instead.');
         }
 
         if (packetReceiveNotification > 0xFFFF) { // Ensure it fits in 16 bits
             throw new Error('DFU procotol cannot use a PRN higher than 0xFFFF.');
         }
 
-        this._prn = packetReceiveNotification;
+        this.prn = packetReceiveNotification;
 
 
-        // Store *one* message waitig to be _read()
-        this._lastReceivedPacket;
+        // Store *one* message waitig to be read()
+        this.lastReceivedPacket = undefined;
 
-        // Store *one* reference to a _read() callback function
-        this._waitingForPacket;
+        // Store *one* reference to a read() callback function
+        this.waitingForPacket = undefined;
 
         // Maximum Transmission Unit. The maximum amount of bytes that can be sent to a
-        // _writeData() call. Its value **must** be filled in by the concrete subclasses 
+        // writeData() call. Its value **must** be filled in by the concrete subclasses
         // before any data is sent.
-        this._mtu = undefined;
+        this.mtu = undefined;
     }
 
     // Abstract method. Concrete subclasses shall implement sending the bytes
     // into the wire/air.
     // The bytes shall include an opcode and payload.
-    _writeCommand(bytes) {}
+    writeCommand(bytes) {}
 
     // Abstract method. Concrete subclasses shall implement sending the bytes
     // into the wire/air.
     // The bytes are all data bytes. Subclasses are responsible for packing
     // this into a command (serial DFU) or sending them through the wire/air
     // through an alternate channel (BLE DFU)
-    _writeData(bytes) {}
+    writeData(bytes) {}
 
 
     // Requests a (decoded and) parsed packet/message, either a response
     // to a previous command or a PRN notification.
     // Returns a Promise to [opcode, Uint8Array].
     // Cannot have more than one pending request at any time.
-    _read() {
-        if (this._waitingForPacket) {
-            throw new Error('DFU transport tried to _read() while another _read() was still waiting');
+    read() {
+        if (this.waitingForPacket) {
+            throw new Error('DFU transport tried to read() while another read() was still waiting');
         }
 
-        if (this._lastReceivedPacket) {
-            let packet = this._lastReceivedPacket;
-            delete this._lastReceivedPacket;
+        if (this.lastReceivedPacket) {
+            const packet = this.lastReceivedPacket;
+            delete this.lastReceivedPacket;
             return Promise.resolve(packet);
         }
 
-        /// Store the callback so it can be called as soon as the wire packet is
-        /// ready. Add a 5sec timeout while we're at it.
+        // Store the callback so it can be called as soon as the wire packet is
+        // ready. Add a 5sec timeout while we're at it.
         return Promise.race([
-            new Promise((res)=>{
-                this._waitingForPacket = res;
+            new Promise(res => {
+                this.waitingForPacket = res;
             }),
-            new Promise((res, rej)=>{
-                setTimeout(()=>{
-                    if (this._waitingForPacket && this._waitingForPacket === res) {
-                        delete this._waitingForPacket;
+            new Promise((res, rej) => {
+                setTimeout(() => {
+                    if (this.waitingForPacket && this.waitingForPacket === res) {
+                        delete this.waitingForPacket;
                     }
-                    rej('Timeout while reading from transport. Is the nRF in bootloader mode?')
+                    rej('Timeout while reading from transport. Is the nRF in bootloader mode?');
                 }, 5000);
-            })
+            }),
         ]);
     }
 
     // Must be called when a (complete) packet/message is received, with the
     // (decoded) bytes of the entire packet/message. Either stores the packet
-    // just received, or calls the pending _read() callback to unlock it
-    _onData(bytes) {
-        if (this._lastReceivedPacket) {
+    // just received, or calls the pending read() callback to unlock it
+    onData(bytes) {
+        if (this.lastReceivedPacket) {
             throw new Error('DFU transport received two messages at once');
         }
 
-        if (this._waitingForPacket) {
-            let callback = this._waitingForPacket;
-            delete this._waitingForPacket;
-            return callback(this._parse(bytes));
+        if (this.waitingForPacket) {
+            const callback = this.waitingForPacket;
+            delete this.waitingForPacket;
+            return callback(this.parse(bytes));
         }
 
-        this._lastReceivedPacket = this._parse(bytes);
+        this.lastReceivedPacket = this.parse(bytes);
+        return undefined;
     }
 
     // Abstract method, called before any operation that would send bytes.
@@ -115,13 +116,13 @@ export default class DfuTransportPrn extends DfuAbstractTransport {
     //   - Set up PRN
     //   - Request MTU (only if the transport has a variable MTU)
     // - Return a Promise whenever the connection is ready.
-    _ready() {}
+    ready() {}
 
 
     // Parses a received DFU response packet/message, does a couple of checks,
     // then returns an array of the form [opcode, payload] if the
     // operation was sucessful.
-    _parse(bytes) {
+    parse(bytes) {
 // console.log('Received SLIP packet: ', bytes);
         if (bytes[0] !== 0x60) {
             return Promise.reject('Response from DFU target did not start with 0x60');
@@ -134,8 +135,9 @@ export default class DfuTransportPrn extends DfuAbstractTransport {
         } else if (resultCode === 0x00) {
             return Promise.reject('Received error from DFU target: Missing or malformed opcode');
         } else if (resultCode === 0x02) {
-            return this._read();
-            return Promise.reject('Received error from DFU target: Invalid opcode');
+            return this.read();
+            // TODO: why two returns here?
+            // return Promise.reject('Received error from DFU target: Invalid opcode');
         } else if (resultCode === 0x03) {
             return Promise.reject('Received error from DFU target: A parameter for the opcode was missing, or unsupported opcode');
         } else if (resultCode === 0x04) {
@@ -150,25 +152,23 @@ export default class DfuTransportPrn extends DfuAbstractTransport {
             return Promise.reject('Received error from DFU target: Operation failed');
         } else if (resultCode === 0x0A) {
             return Promise.reject('Received error from DFU target: Extended error');
-        } else {
-            return Promise.reject('Received unknown result code from DFU target: ' + resultCode);
         }
+        return Promise.reject(`Received unknown result code from DFU target: ${resultCode}`);
     }
 
 
     // Returns a *function* that checks a [opcode, bytes] parameter against the given
     // opcode and byte length, and returns only the bytes.
     // If the opcode is different, or the payload length is different, an error is thrown.
-    _assertPacket(expectedOpcode, expectedLength) {
-        return (response)=>{
-            
+    assertPacket(expectedOpcode, expectedLength) {
+        return response => {
             if (!response) {
                 debug('Tried to assert an empty parsed response!');
                 debug('response: ', response);
                 throw new Error('Tried to assert an empty parsed response!');
             }
             const [opcode, bytes] = response;
-            
+
             if (opcode !== expectedOpcode) {
                 throw new Error(`Expected a response with opcode ${expectedOpcode}, got ${opcode} instead.`);
             }
@@ -182,37 +182,35 @@ export default class DfuTransportPrn extends DfuAbstractTransport {
     }
 
 
-    _createObject(type, size) {
+    createObject(type, size) {
         debug(`CreateObject type ${type}, size ${size}`);
 
-        return this._ready().then(()=>{
-            return this._writeCommand(new Uint8Array([
+        return this.ready().then(() =>
+            this.writeCommand(new Uint8Array([
                 0x01,   // "Create object" opcode
                 type,
-                size >> 0  & 0xFF,
-                size >> 8  & 0xFF,
-                size >> 16 & 0xFF,
-                size >> 24 & 0xFF
+                size & 0xFF,            // eslint-disable-line no-bitwise
+                (size >> 8) & 0xFF,     // eslint-disable-line no-bitwise
+                (size >> 16) & 0xFF,    // eslint-disable-line no-bitwise
+                (size >> 24) & 0xFF,    // eslint-disable-line no-bitwise
             ]))
-            .then(this._read.bind(this))
-            .then(this._assertPacket(0x01, 0));
-
-        });
+            .then(this.read.bind(this))
+            .then(this.assertPacket(0x01, 0)),
+        );
     }
 
-    _writeObject(bytes, crcSoFar, offsetSoFar) {
+    writeObject(bytes, crcSoFar, offsetSoFar) {
         debug('WriteObject');
-        return this._ready().then(()=>{
-            return this._writeObjectPiece(bytes, crcSoFar, offsetSoFar, 0);
-        })
+        return this.ready().then(() =>
+            this.writeObjectPiece(bytes, crcSoFar, offsetSoFar, 0),
+        );
     }
 
-    // Sends *one* write operation (with up to this._mtu bytes of un-encoded data)
+    // Sends *one* write operation (with up to this.mtu bytes of un-encoded data)
     // Triggers a counter-based PRN confirmation
-    _writeObjectPiece(bytes, crcSoFar, offsetSoFar, prnCount) {
-        return this._ready().then(()=>{
-
-            const sendLength = Math.min(this._mtu, bytes.length);
+    writeObjectPiece(bytes, crcSoFar, offsetSoFar, prnCount) {
+        return this.ready().then(() => {
+            const sendLength = Math.min(this.mtu, bytes.length);
 //             const sendLength = 1; // DEBUG
 
             const bytesToSend = bytes.subarray(0, sendLength);
@@ -220,51 +218,48 @@ export default class DfuTransportPrn extends DfuAbstractTransport {
 //             packet.set([0x08], 0);    // "Write" opcode
 //             packet.set(bytesToSend, 1);
 
-            offsetSoFar += sendLength;
-            crcSoFar = crc32(bytesToSend, crcSoFar);
-            prnCount += 1;
+            const newOffsetSoFar = offsetSoFar + sendLength;
+            const newCrcSoFar = crc32(bytesToSend, crcSoFar);
+            let newPrnCount = prnCount + 1;
 
-            return this._writeData(bytesToSend)
-            .then(()=>{
-                if (this._prn > 0 && prnCount >= this._prn) {
+            return this.writeData(bytesToSend)
+            .then(() => {
+                if (this.prn > 0 && newPrnCount >= this.prn) {
                     debug('PRN hit, expecting CRC');
                     // Expect a CRC due to PRN
-                    prnCount = 0;
-                    return this._readCrc().then(([offset, crc])=>{
-                        if (offsetSoFar === offset && crcSoFar === crc) {
+                    newPrnCount = 0;
+                    return this.readCrc().then(([offset, crc]) => {
+                        if (newOffsetSoFar === offset && newCrcSoFar === crc) {
                             debug(`PRN checksum OK at offset ${offset} (0x${offset.toString(16)}) (0x${crc.toString(16)})`);
-                            return;
-                        } else {
-                            return Promise.reject(`CRC mismatch during PRN at byte ${offset}/${offsetSoFar}, expected 0x${crcSoFar.toString(16)} but got 0x${crc.toString(16)} instead`);
+                            return undefined;
                         }
+                        return Promise.reject(`CRC mismatch during PRN at byte ${offset}/${newOffsetSoFar}, expected 0x${newCrcSoFar.toString(16)} but got 0x${crc.toString(16)} instead`);
                     });
-                } else {
-                    // Expect no explicit response
-                    return;
                 }
+                return undefined;
             })
-//             .then(()=>new Promise(res=>{setTimeout(res, 100);}))    // Synthetic timeout for debugging
-            .then(()=>{
+            .then(() => {
                 if (sendLength < bytes.length) {
                     // Send more stuff
-                    return this._writeObjectPiece(bytes.subarray(sendLength), crcSoFar, offsetSoFar, prnCount);
-                } else {
-                    return [offsetSoFar, crcSoFar];
+                    return this.writeObjectPiece(
+                        bytes.subarray(sendLength), newCrcSoFar, newOffsetSoFar, newPrnCount,
+                    );
                 }
-            })
+                return [newOffsetSoFar, newCrcSoFar];
+            });
         });
     }
 
     // Reads a PRN CRC response and returns the offset/CRC pair
-    _readCrc() {
-        return this._ready().then(()=>{
-            return this._read()
-            .then(this._assertPacket(0x03, 8))
-            .then((bytes)=>{
+    readCrc() {
+        return this.ready().then(() =>
+            this.read()
+            .then(this.assertPacket(0x03, 8))
+            .then(bytes => {
                 // Decode little-endian fields
-                const bytesView = new DataView( bytes.buffer );
-                const offset    = bytesView.getUint32(bytes.byteOffset + 0, true);
-                const crc       = bytesView.getUint32(bytes.byteOffset + 4, true);
+                const bytesView = new DataView(bytes.buffer);
+                const offset = bytesView.getUint32(bytes.byteOffset + 0, true);
+                const crc = bytesView.getUint32(bytes.byteOffset + 4, true);
 
 //                 // DEBUG: Once in every 11 CRC responses, apply a XOR to the CRC
 //                 // to make it look like something has failed.
@@ -277,60 +272,53 @@ export default class DfuTransportPrn extends DfuAbstractTransport {
 //                 }
 
                 return [offset, crc];
-            });
-        });
+            }),
+        );
     }
 
-    _crcObject() {
+    crcObject() {
         debug('Request CRC explicitly');
 
-        return this._ready().then(()=>{
-            return this._writeCommand(new Uint8Array([
-                0x03   // "CRC" opcode
+        return this.ready().then(() =>
+            this.writeCommand(new Uint8Array([
+                0x03,   // "CRC" opcode
             ]))
-            .then(this._readCrc.bind(this));
-        });
+            .then(this.readCrc.bind(this)),
+        );
     }
 
-    _executeObject() {
-        debug('Execute (mark payload chunk as ready)')
-        return this._ready().then(()=>{
+    executeObject() {
+        debug('Execute (mark payload chunk as ready)');
+        return this.ready().then(() =>
 //             return new Promise(res=>{setTimeout(res, 5000);})    // Synthetic timeout for debugging
-            return this._writeCommand(new Uint8Array([
-                0x04   // "Execute" opcode
+            this.writeCommand(new Uint8Array([
+                0x04,   // "Execute" opcode
             ]))
 //             .then(()=>new Promise(res=>{setTimeout(res, 5000);}))    // Synthetic timeout for debugging
-            .then(this._read.bind(this))
-            .then(this._assertPacket(0x04, 0));
-        });
+            .then(this.read.bind(this))
+            .then(this.assertPacket(0x04, 0)),
+        );
     }
 
-    _selectObject(type) {
+    selectObject(type) {
         debug('Select (report max size and current offset/crc)');
 
-        return this._ready().then(()=>{
-            return this._writeCommand(new Uint8Array([
+        return this.ready().then(() =>
+            this.writeCommand(new Uint8Array([
                 0x06,   // "Select object" opcode
-                type
+                type,
             ]))
-            .then(this._read.bind(this))
-            .then(this._assertPacket(0x06, 12))
-            .then((bytes)=>{
-
+            .then(this.read.bind(this))
+            .then(this.assertPacket(0x06, 12))
+            .then(bytes => {
                 // Decode little-endian fields
-                const bytesView = new DataView( bytes.buffer );
+                const bytesView = new DataView(bytes.buffer);
                 const chunkSize = bytesView.getUint32(bytes.byteOffset + 0, true);
-                const offset    = bytesView.getUint32(bytes.byteOffset + 4, true);
-                const crc       = bytesView.getUint32(bytes.byteOffset + 8, true);
+                const offset = bytesView.getUint32(bytes.byteOffset + 4, true);
+                const crc = bytesView.getUint32(bytes.byteOffset + 8, true);
                 debug(`selected ${type}: offset ${offset}, crc ${crc}, max size ${chunkSize}`);
                 return [offset, crc, chunkSize];
-            });
-
-//             console.log('Should send select message');
-        });
+            }),
+        );
     }
 }
-
-
-
-

--- a/src/DfuTransportSerial.js
+++ b/src/DfuTransportSerial.js
@@ -1,9 +1,8 @@
-
 import * as slip from 'slip';
 
-const debug = require('debug')('dfu:serial');
-
 import DfuTransportPrn from './DfuTransportPrn';
+
+const debug = require('debug')('dfu:serial');
 
 
 /**
@@ -16,13 +15,13 @@ export default class DfuTransportSerial extends DfuTransportPrn {
     constructor(serialPort, packetReceiveNotification = 16) {
         super(packetReceiveNotification);
 
-        this._port = serialPort;
+        this.port = serialPort;
     }
 
 
     // Given a command (including opcode), perform SLIP encoding and send it
     // through the wire.
-    _writeCommand(bytes) {
+    writeCommand(bytes) {
         let encoded = slip.encode(bytes);
 
         // Strip the heading 0xC0 character, as to avoid a bug in the nRF SDK implementation
@@ -32,50 +31,49 @@ export default class DfuTransportSerial extends DfuTransportPrn {
         // Cast the Uint8Array info a Buffer so it works on nodejs v6
         encoded = new Buffer(encoded);
 
-        return new Promise((res, rej)=>{
+        return new Promise(res => {
             debug(' send --> ', encoded);
-            this._port.write(encoded, res);
+            this.port.write(encoded, res);
         });
     }
 
     // Given some payload bytes, pack them into a 0x08 command.
-    // The length of the bytes is guaranteed to be under this._mtu thanks
+    // The length of the bytes is guaranteed to be under this.mtu thanks
     // to the DfuTransportPrn functionality.
-    _writeData(bytes) {
+    writeData(bytes) {
         const commandBytes = new Uint8Array(bytes.length + 1);
         commandBytes.set([0x08], 0); // "Write" opcode
         commandBytes.set(bytes, 1);
-        return this._writeCommand(commandBytes);
+        return this.writeCommand(commandBytes);
     }
 
     // Opens the port, sets the PRN, requests the MTU.
     // Returns a Promise when initialization is done.
-    _ready() {
-        if (this._readyPromise) {
-            return this._readyPromise;
+    ready() {
+        if (this.readyPromise) {
+            return this.readyPromise;
         }
 
-        return this._readyPromise = new Promise((res)=>{
-            debug(`Opening serial port.`);
+        this.readyPromise = new Promise(res => {
+            debug('Opening serial port.');
 
-            this._port.open(()=>{
-                debug(`Initializing DFU protocol (PRN and MTU).`);
-
+            this.port.open(() => {
+                debug('Initializing DFU protocol (PRN and MTU).');
                 // Start listening for data, and pipe it all through a SLIP decoder.
                 // This code will listen to events from the SLIP decoder instead
                 // of from the serial port itself.
-                this._slipDecoder = new slip.Decoder({
-                    onMessage: this._onData.bind(this)
+                this.slipDecoder = new slip.Decoder({
+                    onMessage: this.onData.bind(this),
                 });
-//                 this._port.on('data', (data)=>this._slipDecoder.decode(data));
+//                 this.port.on('data', (data)=>this.slipDecoder.decode(data));
 
-                this._port.on('data', (data)=>{
+                this.port.on('data', data => {
                     debug(' recv <-- ', data);
-//                     return this._slipDecoder.decode.bind(this._slipDecoder)(data);
-                    return this._slipDecoder.decode(data);
+//                     return this.slipDecoder.decode.bind(this.slipDecoder)(data);
+                    return this.slipDecoder.decode(data);
                 });
 
-//                 this._port.on('data', this._slipDecoder.decode.bind(this._slipDecoder));
+//                 this.port.on('data', this.slipDecoder.decode.bind(this.slipDecoder));
 
 
                 // Ping
@@ -83,8 +81,8 @@ export default class DfuTransportSerial extends DfuTransportPrn {
 //                     0x09,   // "Ping" opcode
 //                     0xAB    // Ping ID
 //                 ]))
-//                 .then(this._read.bind(this))
-//                 .then(this._assertPacket(0x09, 1))
+//                 .then(this.read.bind(this))
+//                 .then(this.assertPacket(0x09, 1))
 //                 .then((bytes)=>{
 //                     if (bytes[0] !== 0xAB) {
 //                         throw new Error('Expected a ping ID of 0xAB, got ' + bytes + ' instead');
@@ -92,100 +90,95 @@ export default class DfuTransportSerial extends DfuTransportPrn {
 //                 })
 
                 // Set PRN
-                let result = this._writeCommand(new Uint8Array([
+                const result = this.writeCommand(new Uint8Array([
                     0x02,  // "Set PRN" opcode
-                    this._prn >> 0 & 0xFF, // PRN LSB
-                    this._prn >> 8 & 0xFF, // PRN MSB
+                    // eslint-disable-next-line no-bitwise
+                    this.prn & 0xFF, // PRN LSB
+                    // eslint-disable-next-line no-bitwise
+                    (this.prn >> 8) & 0xFF, // PRN MSB
                 ]))
-                .then(this._read.bind(this))
-                .then(this._assertPacket(0x02, 0))
+                .then(this.read.bind(this))
+                .then(this.assertPacket(0x02, 0))
                 // Request MTU
-                .then(()=>this._writeCommand(new Uint8Array([
-                    0x07    // "Request serial MTU" opcode
+                .then(() => this.writeCommand(new Uint8Array([
+                    0x07,    // "Request serial MTU" opcode
                 ])))
-                .then(this._read.bind(this))
-                .then(this._assertPacket(0x07, 2))
-                .then((bytes)=>{
-
-                    let mtu =
-                        bytes[1] * 256 +
-                        bytes[0];
+                .then(this.read.bind(this))
+                .then(this.assertPacket(0x07, 2))
+                .then(bytes => {
+                    const mtu = (bytes[1] * 256) + bytes[0];
 
                     // Convert wire MTU into max size of data before SLIP encoding:
                     // This takes into account:
                     // - SLIP encoding ( /2 )
                     // - SLIP end separator ( -1 )
                     // - Serial DFU write command ( -1 )
-                    this._mtu = Math.floor((mtu / 2) - 2);
+                    this.mtu = Math.floor((mtu / 2) - 2);
 
                     // Round down to multiples of 4.
                     // This is done to avoid errors while writing to flash memory:
                     // writing an unaligned number of bytes will result in an
                     // error in most chips.
-                    this._mtu -= this._mtu % 4;
+                    this.mtu -= this.mtu % 4;
 
-// DEBUG: Force a specific MTU.
-this._mtu = Math.min(this._mtu, 20);
+                    // DEBUG: Force a specific MTU.
+                    this.mtu = Math.min(this.mtu, 20);
 
-                    debug(`Serial wire MTU: ${mtu}; un-encoded data max size: ${this._mtu}`);
+                    debug(`Serial wire MTU: ${mtu}; un-encoded data max size: ${this.mtu}`);
                 });
 
                 return res(result);
             });
         });
+        return this.readyPromise;
     }
 
     getProtocolVersion() {
-        if (this._readyPromise) {
-            return this._readyPromise;
+        if (this.readyPromise) {
+            return this.readyPromise;
         }
-        return this._readyPromise = new Promise(res => {
-            this._port.open(() => {
-                this._slipDecoder = new slip.Decoder({
-                    onMessage: this._onData.bind(this)
+        this.readyPromise = new Promise(res => {
+            this.port.open(() => {
+                this.slipDecoder = new slip.Decoder({
+                    onMessage: this.onData.bind(this),
                 });
 
-                this._port.on('data', (data)=>{
-                    return this._slipDecoder.decode(data);
-                });
+                this.port.on('data', data => this.slipDecoder.decode(data));
 
-                const result = this._writeCommand(new Uint8Array([
+                const result = this.writeCommand(new Uint8Array([
                     0x00,  // "Version Command" opcode
                 ]))
-                .then(this._read.bind(this))
-                .then(this._assertPacket(0x00, 1))
-                .then(protocolVersion => {
-                    return protocolVersion[0];
-                })
-                .catch(err => {
-                    console.log(err);
-                });
+                .then(this.read.bind(this))
+                .then(this.assertPacket(0x00, 1))
+                .then(protocolVersion => protocolVersion[0])
+                .catch(debug);
 
                 return res(result);
             });
         });
+        return this.readyPromise;
     }
 
     getHardwareVersion() {
-        if (this._readyPromise) {
-            return this._readyPromise;
+        if (this.readyPromise) {
+            return this.readyPromise;
         }
-        return this._readyPromise = new Promise(res => {
-            this._port.open(() => {
-                this._slipDecoder = new slip.Decoder({
-                    onMessage: this._onData.bind(this)
+        this.readyPromise = new Promise(res => {
+            this.port.open(() => {
+                this.slipDecoder = new slip.Decoder({
+                    onMessage: this.onData.bind(this),
                 });
 
-                this._port.on('data', (data)=>{
-                    console.log('on event');
-                    return this._slipDecoder.decode(data);
+                this.port.on('data', data => {
+                    debug('on event');
+                    return this.slipDecoder.decode(data);
                 });
 
-                const result = this._writeCommand(new Uint8Array([
+                const result = this.writeCommand(new Uint8Array([
                     0x0A,  // "Version Command" opcode
                 ]))
-                .then(this._read.bind(this))
-                .then(this._assertPacket(0x0A, 16))
+                .then(this.read.bind(this))
+                .then(this.assertPacket(0x0A, 16))
                 .then(hardwareVersion => {
                     const dataView = new DataView(hardwareVersion.buffer);
                     return {
@@ -197,90 +190,73 @@ this._mtu = Math.min(this._mtu, 20);
                         },
                     };
                 })
-                .catch(err => {
-                    console.log(err);
-                });
+                .catch(debug);
 
                 return res(result);
             });
         });
+        return this.readyPromise;
     }
-    
-    getFirmwareVersionPromise(imageCount, firmwareVersion) {
-        if (!imageCount) {
-            imageCount = 0;
-        }
-        if (!firmwareVersion) {
-            firmwareVersion = {};
-        }
-        return this._writeCommand(new Uint8Array([
-                0x0B,  // "Version Command" opcode
-                '0x' + imageCount.toString(16),
-            ]))
-            .then(this._read.bind(this))
-            .then(this._assertPacket(0x0B, 13))
-            .then(data => {
-                const dataView = new DataView(data.buffer);
-                const imgType = dataView.getUint8(3);
-                if (imgType !== parseInt('0xFF')) {
-                    let firmware = {};
-                    firmware.version = dataView.getUint32(4);
-                    firmware.addr = dataView.getUint32(8);
-                    firmware.len = dataView.getUint32(12);
-                    switch (imgType) {
-                        case 0:
-                            firmwareVersion.softdevice = firmware;
-                            break;
-                        case 1:
-                            firmwareVersion.application.push(firmware);
-                            break;
-                        case 2:
-                            firmwareVersion.bootloader = firmware;
-                            break;
-                        default:
-                            throw new Error('Unkown firmware image type');
-                    }
-                    ++imageCount;
-                    return this.getFirmwareVersionPromise(imageCount, firmwareVersion);
+
+    getFirmwareVersionPromise(imageCount = 0, firmwareVersion = {}) {
+        return this.writeCommand(new Uint8Array([
+            0x0B,  // "Version Command" opcode
+            `0x${imageCount.toString(16)}`,
+        ]))
+        .then(this.read.bind(this))
+        .then(this.assertPacket(0x0B, 13))
+        .then(data => {
+            const dataView = new DataView(data.buffer);
+            const imgType = dataView.getUint8(3);
+            if (imgType !== 0xFF) {
+                const firmware = {};
+                firmware.version = dataView.getUint32(4);
+                firmware.addr = dataView.getUint32(8);
+                firmware.len = dataView.getUint32(12);
+                const fwVer = Object.assign(firmwareVersion);
+                switch (imgType) {
+                    case 0:
+                        fwVer.softdevice = firmware;
+                        break;
+                    case 1:
+                        fwVer.application.push(firmware);
+                        break;
+                    case 2:
+                        fwVer.bootloader = firmware;
+                        break;
+                    default:
+                        throw new Error('Unkown firmware image type');
                 }
-                else {
-                    return firmwareVersion;
-                }
-            })
-            .catch(err => {
-                console.log(err);
-            });
+                return this.getFirmwareVersionPromise(imageCount + 1, fwVer);
+            }
+            return firmwareVersion;
+        })
+        .catch(debug);
     }
 
     getFirmwareVersion() {
-        if (this._readyPromise) {
-            return this._readyPromise;
+        if (this.readyPromise) {
+            return this.readyPromise;
         }
-        return this._readyPromise = new Promise(res => {
-            this._port.open(() => {
-                const promises = [];
-
-                this._slipDecoder = new slip.Decoder({
-                    onMessage: this._onData.bind(this)
+        this.readyPromise = new Promise(res => {
+            this.port.open(() => {
+                this.slipDecoder = new slip.Decoder({
+                    onMessage: this.onData.bind(this),
                 });
 
-                this._port.on('data', (data)=>{
-                    const resultData = this._slipDecoder.decode(data);
+                this.port.on('data', data => {
+                    const resultData = this.slipDecoder.decode(data);
 
-                    return resultData; 
+                    return resultData;
                 });
 
 
                 const result = this.getFirmwareVersionPromise()
-                    .then(firmwareVersion => {
-                        return firmwareVersion;
-                    })
+                    .then(firmwareVersion => firmwareVersion);
                 return res(result);
             });
         });
+
+        return this.readyPromise;
     }
 }
-
-
-
-

--- a/src/DfuTransportSink.js
+++ b/src/DfuTransportSink.js
@@ -1,11 +1,10 @@
-
-import DfuAbstractTransport from './DfuAbstractTransport';
-
 // FIXME: Should be `import {crc32} from 'crc'`, https://github.com/alexgorbatchev/node-crc/pull/50
 // import * as crc from 'crc';
 // const crc32 = crc.crc32;
 // import {crc32} from 'crc';
 import crc32 from 'crc/src/crc32';
+
+import DfuAbstractTransport from './DfuAbstractTransport';
 
 const debug = require('debug')('dfu:sink');
 
@@ -17,72 +16,66 @@ const debug = require('debug')('dfu:sink');
  */
 
 
-
 export default class DfuTransportSink extends DfuAbstractTransport {
     constructor(bytesPerSecond = Infinity, chunkSize = 0x1000) {
         super();
 
-        this._bytesPerMilliSecond = bytesPerSecond * 1000;
-        this._chunkSize = chunkSize;
+        this.bytesPerMilliSecond = bytesPerSecond * 1000;
+        this.chunkSize = chunkSize;
 
-        this._offsets = {1: 0, 2: 0};
-        this._crcs = {1: undefined, 2: undefined};
-        this._sizes = {1: 0, 2: 0};
+        this.offsets = { 1: 0, 2: 0 };
+        this.crcs = { 1: undefined, 2: undefined };
+        this.sizes = { 1: 0, 2: 0 };
 
-        this._selected = undefined;
+        this.selected = undefined;
     }
 
-    _createObject(type, size) {
-        this._selectObject(type);
-        this._sizes[type] = size;
+    createObject(type, size) {
+        this.selectObject(type);
+        this.sizes[type] = size;
         debug(`Sink DFU transport: created object of type ${type}, size ${size}`);
         return Promise.resolve();
     }
 
-    _writeObject(bytes, crcSoFar) {
-        if (!this._selected) {
+    writeObject(bytes, crcSoFar) {
+        if (!this.selected) {
             throw new Error('Must create/select a payload type first.');
         }
-        if (crcSoFar !== this._crcs[this._selected]) {
+        if (crcSoFar !== this.crcs[this.selected]) {
             throw new Error('Invoked with a mismatched CRC32 checksum.');
         }
-        if (bytes.length > this._sizes[this._selected]) {
+        if (bytes.length > this.sizes[this.selected]) {
             throw new Error('Tried to push more bytes to a chunk than the chunk size.');
         }
-        this._offsets[this._selected] += bytes.length;
-        this._crcs[this._selected] = crc32(bytes, crcSoFar);
-        return new Promise((res, rej)=>{
-            setTimeout(()=>{
+        this.offsets[this.selected] += bytes.length;
+        this.crcs[this.selected] = crc32(bytes, crcSoFar);
+        return new Promise(res => {
+            setTimeout(() => {
                 debug(`Sink DFU transport: consumed ${bytes.length} bytes`);
-                res([this._offsets[this._selected], this._crcs[this._selected]])
-            }, bytes / this._bytesPerMilliSecond);
+                res([this.offsets[this.selected], this.crcs[this.selected]]);
+            }, bytes / this.bytesPerMilliSecond);
         });
-
     }
 
-    _crcObject() {
-        if (!this._selected) {
+    crcObject() {
+        if (!this.selected) {
             throw new Error('Must create/select a payload type first.');
         }
         return Promise.resolve();
     }
 
-    _executeObject() {
-        if (!this._selected) {
+    executeObject() {
+        if (!this.selected) {
             throw new Error('Must create/select a payload type first.');
         }
         return Promise.resolve();
     }
 
-    _selectObject(type) {
-        if (!this._offsets.hasOwnProperty(type)) {
+    selectObject(type) {
+        if (!this.offsets.hasOwnProperty(type)) {
             throw new Error('Tried to select invalid payload type. Valid types are 0x01 and 0x02.');
         }
-        this._selected = type;
-        return Promise.resolve([ this._offsets[type], this._crcs[type], this._chunkSize ]);
+        this.selected = type;
+        return Promise.resolve([this.offsets[type], this.crcs[type], this.chunkSize]);
     }
 }
-
-
-
-

--- a/src/DfuUpdates.js
+++ b/src/DfuUpdates.js
@@ -1,22 +1,22 @@
-
 import * as JSZip from 'jszip';
 import fs from 'fs';
 
 const debug = require('debug')('dfu:updates');
 
 
-// Object.entries polyfill, as per 
+// Object.entries polyfill, as per
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries
 if (!Object.entries) {
-  Object.entries = function( obj ){
-    var ownProps = Object.keys( obj ),
-        i = ownProps.length,
-        resArray = new Array(i); // preallocate the Array
-    while (i--)
-      resArray[i] = [ownProps[i], obj[ownProps[i]]];
-    
-    return resArray;
-  };
+    Object.entries = obj => {
+        const ownProps = Object.keys(obj);
+        let i = ownProps.length;
+        const resArray = new Array(i); // preallocate the Array
+        while (i) {
+            i -= 1;
+            resArray[i] = [ownProps[i], obj[ownProps[i]]];
+        }
+        return resArray;
+    };
 }
 
 /**
@@ -50,52 +50,48 @@ if (!Object.entries) {
 
 export default class DfuUpdates {
     constructor(updates) {
-        this._updates = updates || [];
+        this.updates = updates || [];
         // FIXME: Perform extra sanity checks, check types of the "updates" array.
-    }
-
-    get updates() {
-        return this._updates;
     }
 
     /**
      * Instantiates a set of DfuUpdates given the *path* of a .zip file.
      * That .zip file is expected to have been created by nrfutil, having
      * a valid manifest.
-     * 
+     *
      * This requires your environment to have access to the local filesystem.
      * (i.e. works in nodejs, not in a web browser)
      *
-     * @param String path The full file path to the .zip file
-     * @return A Promise to an instance of DfuUpdates
+     * @param {String} path The full file path to the .zip file
+     * @return {Promise} A Promise to an instance of DfuUpdates
      */
     static fromZipFilePath(path) {
-        return new Promise((res, rej)=>{
+        return new Promise((res, rej) => {
             fs.readFile(path, (err, data) => {
                 if (err) { return rej(err); }
                 return res(this.fromZipFile(data));
             });
         });
-    }    
-    
+    }
+
     /**
      * Instantiates a set of DfuUpdates given the *contents* of a .zip file,
-     * as an ArrayBuffer, a Uint8Array, Buffer, Blob, or other data type accepted by 
+     * as an ArrayBuffer, a Uint8Array, Buffer, Blob, or other data type accepted by
      * [JSZip](https://stuk.github.io/jszip/documentation/api_jszip/load_async.html).
      * That .zip file is expected to have been created by nrfutil, having
      * a valid manifest.
      *
-     * @param String path The full file path to the .zip file
-     * @return A Promise to an instance of DfuUpdates
+     * @param {String} zipBytes The full file path to the .zip file
+     * @return {Promise} A Promise to an instance of DfuUpdates
      */
     static fromZipFile(zipBytes) {
-        return (new JSZip()).loadAsync(zipBytes).then((zippedFiles)=>{
-            return zippedFiles.file('manifest.json').async('text').then((manifestString)=>{
-
+        return (new JSZip()).loadAsync(zipBytes)
+        .then(zippedFiles =>
+            zippedFiles.file('manifest.json').async('text').then(manifestString => {
                 debug('Unzipped manifest: ', manifestString);
 
                 return JSON.parse(manifestString).manifest;
-            }).then((manifestJson)=>{
+            }).then(manifestJson => {
                 // The manifest should have up to 2 properties along
                 // "softdevice", "bootloader", "softdevice_bootloader",
                 // or "application". At least that's what the standard
@@ -105,38 +101,20 @@ export default class DfuUpdates {
 
                 debug('Parsed manifest:', manifestJson);
 
-                let updates = Object.entries(manifestJson).map(([, updateJson])=>{
+                const updates = Object.entries(manifestJson).map(([, updateJson]) => {
                     const { dat_file, bin_file } = updateJson;
                     const initPacketPromise = zippedFiles.file(dat_file).async('uint8array');
                     const firmwareImagePromise = zippedFiles.file(bin_file).async('uint8array');
 
                     return Promise.all([initPacketPromise, firmwareImagePromise])
-                    .then(([initPacketBytes, firmwareImageBytes])=>{
-                        return {
+                        .then(([initPacketBytes, firmwareImageBytes]) => ({
                             initPacket: initPacketBytes,
-                            firmwareImage: firmwareImageBytes
-                        };
-                    })
+                            firmwareImage: firmwareImageBytes,
+                        }));
                 });
 
-                return Promise.all(updates).then(updates=>{
-                    return new DfuUpdates(updates);
-                });
-            });
-        });
+                return Promise.all(updates)
+                .then(resolvedUpdates => new DfuUpdates(resolvedUpdates));
+            }));
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/ProgressCounter.js
+++ b/src/ProgressCounter.js
@@ -8,35 +8,31 @@
 export default class ProgressCounter {
 
     constructor(targetAmount) {
-        this._target = targetAmount;
+        this.target = targetAmount;
 //         this._startTime = performance.now(); /// TODO: properly use timings
 //         this._lastTime = performance.now();
-        this._current = 0;
+        this.current = 0;
 
-        this._waits = [];
+        this.waits = [];
     }
 
     // Returns a `Promise` that resolves when there has been a
     // progress update, with the progress information at that point.
     // Note that one can `await` for this.
     get nextProgressUpdate() {
-        return new Promise((res)=>{
-            this._waits.push(()=>{
+        return new Promise(res => {
+            this.waits.push(() => {
                 res({
-                    amount: this._current,
-                    percent: this._current / this._target
+                    amount: this.current,
+                    percent: this.current / this.target,
                 });
             });
         });
     }
 
     // Advances the current progress by the given amount (or reduces it if negative)
-    advance(amount){
-        this._current += amount;
-        this._waits.forEach((f)=>f());
+    advance(amount) {
+        this.current += amount;
+        this.waits.forEach(f => f());
     }
-
 }
-
-
-

--- a/src/index.js
+++ b/src/index.js
@@ -1,22 +1,15 @@
-
-
 import DfuOperation from './DfuOperation';
-export {DfuOperation};
-
-// import DfuAbstractTransport from './DfuAbstractTransport';
-// export {DfuAbstractTransport};
-
 import DfuUpdates from './DfuUpdates';
-export {DfuUpdates};
-
 import DfuTransportSink from './DfuTransportSink';
-export {DfuTransportSink};
 import DfuTransportSerial from './DfuTransportSerial';
-export {DfuTransportSerial};
 import DfuTransportNoble from './DfuTransportNoble';
-export {DfuTransportNoble};
-
 import ProgressCounter from './ProgressCounter';
-export {ProgressCounter};
 
-
+export {
+    DfuOperation,
+    DfuUpdates,
+    DfuTransportSink,
+    DfuTransportSerial,
+    DfuTransportNoble,
+    ProgressCounter,
+};


### PR DESCRIPTION
- added eslint configuration
- added babel to rollup, so rollup can understand our flavour of js
- removed dangling underscores
- fixed all of indentation, syntax, assignment and many more issues
- fixed version-command test

TODOs which will **not** be included in this PR:

- move crc32 and slip code into this repo, they are only 2 small functions and pulling them from outside is too problematic
- consider removing rollup, is there any need for it?
- remove commented out code
- check what's needed in DfuTransportPrn.js:139, consider a switch or a map of error messages for cleaner code
- change members not using `this` to static
- follow up remaining linting error