### PR TITLE
Add "Slow Serial" transport

### DIFF
--- a/src/DfuTransportSerial.js
+++ b/src/DfuTransportSerial.js
@@ -74,15 +74,19 @@ export default class DfuTransportSerial extends DfuTransportPrn {
                     onMessage: this.onData.bind(this),
                 });
 
-                this.port.on('data', data => {
-                    debug(' recv <-- ', data);
-                    return this.slipDecoder.decode(data);
-                });
+                this.port.on('data', this.onRawData.bind(this));
 
                 return res();
             });
         });
         return this.openPromise;
+    }
+
+    // Callback when raw (yet undecoded by SLIP) data is being read from the serial port instance.
+    // Called only internally.
+    onRawData(data) {
+        debug(' recv <-- ', data);
+        return this.slipDecoder.decode(data);
     }
 
     // Initializes DFU procedure: sets the PRN and requests the MTU.

--- a/src/DfuTransportSlowSerial.js
+++ b/src/DfuTransportSlowSerial.js
@@ -1,0 +1,45 @@
+
+import DfuTransportSerial from './DfuTransportSerial';
+
+const debug = require('debug')('dfu:slowserial');
+
+/**
+ * Slow serial DFU transport.
+ *
+ * Just like the Serial DFU transport, but adds a synthetic delay when
+ * receiving SLIP packets.
+ * It can also lower the data MTU, to trigger sending more messages for
+ * each data payload.
+ */
+
+export default class DfuTransportSlowSerial extends DfuTransportSerial {
+    // Delay is in milliseconds
+    constructor(serialPort, delay = 50, packetReceiveNotification = 16, maxMtu = Infinity) {
+        super(serialPort, packetReceiveNotification);
+
+        this.delay = delay;
+        this.maxMtu = maxMtu;
+    }
+
+    // Callback when raw (yet undecoded by SLIP) data is being read from the serial port instance.
+    // Called only internally.
+    onRawData(data) {
+        setTimeout(() => {
+            super.onRawData(data);
+        }, this.delay);
+    }
+
+    // Decorate ready() so it hijacks the value of the MTU.
+    ready() {
+        if (this.readyPromise) {
+            return this.readyPromise;
+        }
+
+        return super.ready().then(() => { 
+            const mtu = Math.min(this.mtu, this.maxMtu);
+            debug(`Hijacking MTU value, now: ${mtu}`);
+            this.mtu = mtu; 
+        });
+    }
+}
+

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import DfuOperation from './DfuOperation';
 import DfuUpdates from './DfuUpdates';
 import DfuTransportSink from './DfuTransportSink';
 import DfuTransportSerial from './DfuTransportSerial';
+import DfuTransportSlowSerial from './DfuTransportSlowSerial';
 import DfuTransportNoble from './DfuTransportNoble';
 import ProgressCounter from './ProgressCounter';
 
@@ -10,6 +11,7 @@ export {
     DfuUpdates,
     DfuTransportSink,
     DfuTransportSerial,
+    DfuTransportSlowSerial,
     DfuTransportNoble,
     ProgressCounter,
 };


### PR DESCRIPTION
This PR adds a new transport: "Slow Serial". This is just a nicer way of structuring (i.e. not commenting/uncommenting code) two hacks I've been using to debug the DFU protocol: add a delay to any serial reads, and forcefully set a small MTU.

This is good just for testing/debugging the DFU protocol (mostly due to the timing issues in `nrfjprog`'s RTT). A smaller MTU lets data flow slower and spawn more packets, triggering PRN easier.

We don't really need to merge this into `master`, but it might be good to have it around if we need to go debugging the DFU protocol again.