### PR TITLE
Reject an error instead of a string when receiving an error code from target

### DIFF
--- a/src/DfuTransportPrn.js
+++ b/src/DfuTransportPrn.js
@@ -156,7 +156,7 @@ export default class DfuTransportPrn extends DfuAbstractTransport {
         }
 
         debug(errorStr);
-        return Promise.reject(errorStr);
+        return Promise.reject(new Error(errorStr));
     }
 
 


### PR DESCRIPTION
I'm running into a case where a extended error is triggered, when trying to perform a DFU from a `nrf-device-setup` script.

This change makes the extended error raise up to the `nrf-device-setup` code; without this change, it will just raise as `undefined`. (I'm a bit puzzled on the why, though)