### PR TITLE
Rephrase error message on serial timeout, so user can suspect about USB CDC drivers

### DIFF
--- a/src/DfuTransportPrn.js
+++ b/src/DfuTransportPrn.js
@@ -102,7 +102,7 @@ export default class DfuTransportPrn extends DfuAbstractTransport {
                     if (this.waitingForPacket && this.waitingForPacket === res) {
                         delete this.waitingForPacket;
                     }
-                    rej(new Error('Timeout while reading from transport. Is the nRF in bootloader mode?'));
+                    rej(new Error('Timeout while reading from serial transport. See https://github.com/NordicSemiconductor/pc-nrfconnect-core/blob/master/doc/serial-timeout-troubleshoot.md'));
                 }, 5000);
             }),
         ]);


### PR DESCRIPTION
When this error message was originally written, the failure scenario was trying to DFU a devkit/dongle in application mode (e.g. running the RSSI monitor firmware), which would ignore DFU commands.

However, we've seen this error message popping up whenever the USB CDC ACM drivers on windows are missing / malfunctioning, and on Mac on some other scenario.

This change aims to point the user to another possible cause of the problem, not only the bootloader mode of the devkit/dongle. The existing error message can be understood as "the only reason this can fail is the nRF not being in bootloader mode" (which can frustrate the user if the only thing they do is make sure that the devkit/dongle is in bootloader mode); this change aims to make the user question whether the problem might be on the PC side of things.