### PR TITLE
Rework the serial read timeout callback; no-op on USB post-DFU CRC

### DIFF
--- a/src/DfuTransportUsbSerial.js
+++ b/src/DfuTransportUsbSerial.js
@@ -111,7 +111,12 @@ export default class DfuTransportUsbSerial extends DfuTransportSerial {
             // transport will keep waiting for a CRC response.
             this.writeCommand(new Uint8Array([
                 0x03, // "CRC" opcode
-            ]));
+            ])).catch(err => {
+                // No-op in case of an (expected) error, makes this return a
+                // fulfilled promise instead of a rejected one.
+                // Some scenarios in a win7 platform trigger a "Error 1167" when
+                // attempting to write with the port closed.
+            });
         }, 250);
 
         let timeout;


### PR DESCRIPTION
This is a blind attempt to fix the errors showing up on @bjornspock / @bjornspockeli's environment.

There was a bug inadvertently introduced at https://github.com/NordicPlayground/pc-nrf-dfu-js/commit/3c1285a7e81f25dd46bebe6db7bbcc7d01d0a6a1#diff-88578acf92ddf5b1b1518253a68031b0R87 : the `this._waitingForPacket === res` check uses the wrong reference to `res` (instead of the one being assigned to `this._waitingForPacket` a few lines above).

The current implementation should work around that, **and** the `clearTimeout` should prevent all the promise rejections from happening (which otherwise would hinder debugging in these hard-to-reproduce scenarios). This comes at the cost of one more function wrapper in the call stack, which I think it's negligible (or at least, worth it).

---

This also adds a `.catch()` statement on the fake CRC request introduced at https://github.com/NordicPlayground/pc-nrf-dfu-js/commit/217231cd393a36b89140220c245c4eef4a2db850 / https://github.com/NordicPlayground/pc-nrf-dfu-js/commit/90519806791e295225e807135cef260e9498e5e5 . 

My *suspicion* is that @bjornspockeli's `error 1167` is triggered in the callback to the `write()` function of the `serialport` instance, causing an uncaught promise rejection, that somehow bubbles up as an uncaught exception and stops a DFU procedure when used in `pc-nrfconnect-core`. As this write request is made after the USB-CDC-ACM device has been disconnected, it should be completely safe to catch and ignore errors.

