### PR TITLE
Write up-to-date comments about waitForDisconnect()

### DIFF
--- a/src/DfuTransportUsbSerial.js
+++ b/src/DfuTransportUsbSerial.js
@@ -74,8 +74,14 @@ export default class DfuTransportUsbSerial extends DfuTransportSerial {
             });
     }
 
-    // Waits for the target to disconnect. Times out if not
-    // disconnected after 5000 ms.
+    // Ideally, this should *wait* for the DFU target to be disconnected
+    // (by means of listening to the serialport's `close` event). Unfortunately
+    // there are several scenarios where this doesn't happen: macOS and
+    // 64-bit win. Previous implementations ( < v0.2.5) had workarounds,
+    // but those workarounds created problems on a specific USB XHCI root hub
+    // on win7 64-bit.
+    // The current implementation **assumes** that the DFU target will reset
+    // itself.
     waitForDisconnect() {
         if (!this.port || !this.port.isOpen) {
             debug('Port is already closed.');


### PR DESCRIPTION
The changes in #33 (inadvertently) left some old comments which are no longer true (i.e. the `waitForDisconnect()` function no longer times out after 5 sec). This just gets those comments up to date.