### PR TITLE
Fix invalid upper bound computation

### DIFF
--- a/src/DfuAbstractTransport.js
+++ b/src/DfuAbstractTransport.js
@@ -120,7 +120,7 @@ export default class DfuAbstractTransport {
                     debug(`Payload partially transferred sucessfully, continuing from offset ${offset}.`);
 
                     // Send the remainder of a half-finished chunk
-                    const end = (offset + chunkSize) - (offset % chunkSize);
+                    const end = Math.min(bytes.length, (offset + chunkSize) - (offset % chunkSize));
 
                     return this.sendAndExecutePayloadChunk(
                         type, bytes, offset,


### PR DESCRIPTION
When resuming from the final chunk, the upper bound was wrongly computed
and went past the end of the image.