### PR TITLE
Update dependencies, fix rollup, cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrf-dfu-js",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "JS implementation of the nRF DFU protocol",
   "esnext:main": "src/index.js",
   "main": "dist/nrf-dfu.cjs.js",
@@ -10,32 +10,30 @@
   "license": "Propietary",
   "scripts": {
     "rollup": "rollup -c rollup.config.js",
-    "test": "rollup -c rollup.config.js && DEBUG=dfu:test jest --detectOpenHandles --runInBand",
+    "test": "rollup -c rollup.config.js && jest --detectOpenHandles --runInBand",
     "lint": "eslint src/"
   },
-  "dependencies": {
-    "jszip": "^3.1.4"
-  },
   "peerDependencies": {
-    "serialport": "^6.2.0"
+    "serialport": "^7.1.5"
   },
   "devDependencies": {
-    "debug": "^3.1.0",
-    "eslint": "^4.15.0",
-    "eslint-config-airbnb-base": "^12.1.0",
-    "eslint-plugin-import": "^2.14.0",
-    "eslint-plugin-react": "^7.11.1",
-    "jest": "^23.5.0",
+    "debug": "^4.1.1",
+    "eslint": "^6.0.1",
+    "eslint-config-airbnb-base": "^13.2.0",
+    "eslint-plugin-import": "^2.18.0",
+    "eslint-plugin-react": "^7.14.2",
+    "jest": "^24.8.0",
     "pc-nrfconnect-build": "git+https://github.com/NordicPlayground/pc-nrfconnect-build.git#semver:^0.0.1",
     "jest-bamboo-formatter": "1.0.1",
-    "jest-serializer-path": "^0.1.14",
-    "rollup": "^0.50.0",
-    "rollup-plugin-commonjs": "^8.2.1",
-    "rollup-plugin-eslint": "^4.0.0",
+    "jest-serializer-path": "^0.1.15",
+    "jszip": "^3.2.2",
+    "rollup": "^1.16.6",
+    "rollup-plugin-commonjs": "^10.0.1",
+    "rollup-plugin-eslint": "^7.0.0",
     "rollup-plugin-node-builtins": "^2.1.2",
-    "rollup-plugin-node-globals": "^1.1.0",
-    "rollup-plugin-node-resolve": "^3.0.0",
-    "serialport": "^6.2.0"
+    "rollup-plugin-node-globals": "^1.4.0",
+    "rollup-plugin-node-resolve": "^5.2.0",
+    "serialport": "^7.1.5"
   },
   "jest": {
     "testMatch": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,9 +1,8 @@
-
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 import builtins from 'rollup-plugin-node-builtins';
 import globals from 'rollup-plugin-node-globals';
-import eslint from 'rollup-plugin-eslint';
+import { eslint } from 'rollup-plugin-eslint';
 import pkg from './package.json';
 
 export default [
@@ -13,20 +12,16 @@ export default [
         output: {
             file: pkg.browser,
             format: 'iife',
-            sourcemap: true
+            sourcemap: true,
+            name: 'nrfDfu',
         },
-        external: ['jszip'],
-        globals: {
-            jszip: 'JSZip'
-        },
-        name: 'nrfDfu',
         plugins: [
             eslint(),
-            resolve(), // so Rollup can find `crc32`
+            resolve({ preferBuiltins: true }), // so Rollup can find `crc32`
             commonjs(),
             builtins(),
-            globals()
-        ]
+            globals(),
+        ],
     },
 
     // CommonJS (for Node) and ES module (for bundlers) build.
@@ -36,15 +31,13 @@ export default [
     // the `targets` option which can specify `dest` and `format`)
     {
         input: 'src/index.js',
-        external: ['buffer', 'fs', 'jszip', 'debug'],
+        external: ['buffer', 'fs', 'debug'],
         output: [
             { file: pkg.main, format: 'cjs', sourcemap: true },
-//             { file: pkg.module, format: 'es', sourcemap: true }
         ],
         plugins: [
             eslint(),
-            resolve(), // so Rollup can find `crc32`
-// 			commonjs() // so Rollup can convert `crc32` to an ES module
-        ]
-    }
+            resolve({ preferBuiltins: true }), // so Rollup can find `crc32`
+        ],
+    },
 ];

--- a/src/DfuAbstractTransport.js
+++ b/src/DfuAbstractTransport.js
@@ -37,6 +37,7 @@
  * of the use of this software, even if advised of the possibility of such damage.
  *
  */
+
 import crc32 from './util/crc32';
 import { DfuError, ErrorCode } from './DfuError';
 

--- a/src/DfuError.js
+++ b/src/DfuError.js
@@ -37,6 +37,7 @@
  * of the use of this software, even if advised of the possibility of such damage.
  *
  */
+
 import Debug from 'debug';
 
 const debug = Debug('dfu:error');

--- a/src/DfuOperation.js
+++ b/src/DfuOperation.js
@@ -54,6 +54,7 @@
  * doing things such as service discovery, buttonless BLE DFU initialization, or claiming
  * a USB interface of a USB device.
  */
+
 export default class DfuOperation {
     constructor(dfuUpdates, dfuTransport, autoStart = false) {
         this.updates = dfuUpdates.updates;

--- a/src/DfuTransportNoble.js
+++ b/src/DfuTransportNoble.js
@@ -37,6 +37,7 @@
  * of the use of this software, even if advised of the possibility of such damage.
  *
  */
+
 import Debug from 'debug';
 import DfuTransportPrn from './DfuTransportPrn';
 import { DfuError, ErrorCode } from './DfuError';
@@ -186,14 +187,15 @@ export default class DfuTransportNoble extends DfuTransportPrn {
                     });
                 });
             })
-            .then(() =>
+            .then(() => (
                 this.writeCommand(new Uint8Array([
                     0x02, // "Set PRN" opcode
                     this.prn & 0xFF, // PRN LSB
                     (this.prn >> 8) & 0xFF, // PRN MSB
                 ]))
                     .then(this.read.bind(this))
-                    .then(this.assertPacket(0x02, 0)));
+                    .then(this.assertPacket(0x02, 0))
+            ));
 
         return this.readyPromise;
     }

--- a/src/DfuTransportPrn.js
+++ b/src/DfuTransportPrn.js
@@ -37,9 +37,12 @@
  * of the use of this software, even if advised of the possibility of such damage.
  *
  */
+
 import Debug from 'debug';
 import crc32 from './util/crc32';
-import { DfuError, ErrorCode, ResponseErrorMessages, ExtendedErrorMessages } from './DfuError';
+import {
+    DfuError, ErrorCode, ResponseErrorMessages, ExtendedErrorMessages,
+} from './DfuError';
 import DfuAbstractTransport from './DfuAbstractTransport';
 
 const debug = Debug('dfu:prntransport');
@@ -231,7 +234,7 @@ export default class DfuTransportPrn extends DfuAbstractTransport {
     createObject(type, size) {
         debug(`CreateObject type ${type}, size ${size}`);
 
-        return this.ready().then(() =>
+        return this.ready().then(() => (
             this.writeCommand(new Uint8Array([
                 0x01, // "Create object" opcode
                 type,
@@ -241,13 +244,15 @@ export default class DfuTransportPrn extends DfuAbstractTransport {
                 (size >> 24) & 0xFF,
             ]))
                 .then(this.read.bind(this))
-                .then(this.assertPacket(0x01, 0)));
+                .then(this.assertPacket(0x01, 0))
+        ));
     }
 
     writeObject(bytes, crcSoFar, offsetSoFar) {
         debug('WriteObject');
-        return this.ready().then(() =>
-            this.writeObjectPiece(bytes, crcSoFar, offsetSoFar, 0));
+        return this.ready().then(() => (
+            this.writeObjectPiece(bytes, crcSoFar, offsetSoFar, 0)
+        ));
     }
 
     // Sends *one* write operation (with up to this.mtu bytes of un-encoded data)
@@ -297,7 +302,7 @@ export default class DfuTransportPrn extends DfuAbstractTransport {
 
     // Reads a PRN CRC response and returns the offset/CRC pair
     readCrc() {
-        return this.ready().then(() =>
+        return this.ready().then(() => (
             this.read()
                 .then(this.assertPacket(0x03, 8))
                 .then(bytes => {
@@ -318,33 +323,36 @@ export default class DfuTransportPrn extends DfuAbstractTransport {
                     // }
 
                     return [offset, crc];
-                }));
+                })
+        ));
     }
 
     crcObject() {
         debug('Request CRC explicitly');
 
-        return this.ready().then(() =>
+        return this.ready().then(() => (
             this.writeCommand(new Uint8Array([
                 0x03, // "CRC" opcode
             ]))
-                .then(this.readCrc.bind(this)));
+                .then(this.readCrc.bind(this))
+        ));
     }
 
     executeObject() {
         debug('Execute (mark payload chunk as ready)');
-        return this.ready().then(() =>
+        return this.ready().then(() => (
             this.writeCommand(new Uint8Array([
                 0x04, // "Execute" opcode
             ]))
                 .then(this.read.bind(this))
-                .then(this.assertPacket(0x04, 0)));
+                .then(this.assertPacket(0x04, 0))
+        ));
     }
 
     selectObject(type) {
         debug('Select (report max size and current offset/crc)');
 
-        return this.ready().then(() =>
+        return this.ready().then(() => (
             this.writeCommand(new Uint8Array([
                 0x06, // "Select object" opcode
                 type,
@@ -359,14 +367,16 @@ export default class DfuTransportPrn extends DfuAbstractTransport {
                     const crc = bytesView.getUint32(bytes.byteOffset + 8, true);
                     debug(`selected ${type}: offset ${offset}, crc ${crc}, max size ${chunkSize}`);
                     return [offset, crc, chunkSize];
-                }));
+                })
+        ));
     }
 
     abortObject() {
         debug('Abort (mark payload chunk as ready)');
-        return this.ready().then(() =>
+        return this.ready().then(() => (
             this.writeCommand(new Uint8Array([
                 0x0C, // "Abort" opcode
-            ])));
+            ]))
+        ));
     }
 }

--- a/src/DfuTransportSerial.js
+++ b/src/DfuTransportSerial.js
@@ -37,6 +37,7 @@
  * of the use of this software, even if advised of the possibility of such damage.
  *
  */
+
 import Debug from 'debug';
 import * as slip from './util/slip';
 import { DfuError, ErrorCode } from './DfuError';

--- a/src/DfuTransportSink.js
+++ b/src/DfuTransportSink.js
@@ -37,6 +37,7 @@
  * of the use of this software, even if advised of the possibility of such damage.
  *
  */
+
 import Debug from 'debug';
 import crc32 from './util/crc32';
 import { DfuError, ErrorCode } from './DfuError';

--- a/src/DfuTransportSlowSerial.js
+++ b/src/DfuTransportSlowSerial.js
@@ -37,6 +37,7 @@
  * of the use of this software, even if advised of the possibility of such damage.
  *
  */
+
 import Debug from 'debug';
 import DfuTransportSerial from './DfuTransportSerial';
 

--- a/src/DfuTransportUsbSerial.js
+++ b/src/DfuTransportUsbSerial.js
@@ -37,6 +37,7 @@
  * of the use of this software, even if advised of the possibility of such damage.
  *
  */
+
 import Debug from 'debug';
 import DfuTransportSerial from './DfuTransportSerial';
 import { DfuError, ErrorCode } from './DfuError';

--- a/src/DfuUpdates.js
+++ b/src/DfuUpdates.js
@@ -37,9 +37,11 @@
  * of the use of this software, even if advised of the possibility of such damage.
  *
  */
-import * as JSZip from 'jszip';
+
 import fs from 'fs';
 import Debug from 'debug';
+
+const JSZip = require('jszip/dist/jszip');
 
 const debug = Debug('dfu:updates');
 
@@ -124,7 +126,7 @@ export default class DfuUpdates {
      */
     static fromZipFile(zipBytes) {
         return (new JSZip()).loadAsync(zipBytes)
-            .then(zippedFiles =>
+            .then(zippedFiles => (
                 zippedFiles.file('manifest.json').async('text').then(manifestString => {
                     debug('Unzipped manifest: ', manifestString);
 
@@ -151,6 +153,7 @@ export default class DfuUpdates {
 
                     return Promise.all(updates)
                         .then(resolvedUpdates => new DfuUpdates(resolvedUpdates));
-                }));
+                })
+            ));
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@
  * of the use of this software, even if advised of the possibility of such damage.
  *
  */
+
 import DfuOperation from './DfuOperation';
 import DfuUpdates from './DfuUpdates';
 import DfuTransportSink from './DfuTransportSink';

--- a/src/util/define_crc.js
+++ b/src/util/define_crc.js
@@ -27,14 +27,15 @@ const { Buffer } = require('buffer');
 
 let castToBytes;
 
-if (typeof Uint8Array !== 'undefined' && Uint8Array.from &&
-    typeof TextDecoder !== 'undefined') {
+if (typeof Uint8Array !== 'undefined' && Uint8Array.from
+    && typeof TextDecoder !== 'undefined') {
     const utf8Decoder = new TextDecoder('utf-8');
 
     castToBytes = arr => {
         if (arr instanceof Uint8Array) {
             return arr;
-        } else if (typeof arr === 'string') {
+        }
+        if (typeof arr === 'string') {
             return utf8Decoder(arr);
         }
         return Uint8Array.from(arr);


### PR DESCRIPTION
This PR
- bumps version to 0.2.8
- updates dependencies
- rolls up jszip, so external dependency is not needed
- fixes linting errors