### PR TITLE
Correct reference to project core/launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 `pc-nrf-dfu-js` is a Javascript module which provides DFU (Device Firmware Upgrade) via USB CDC ACM transport for Nordic devices.
 
-This module is primarily used by the [nRF Connect](https://github.com/NordicSemiconductor/pc-nrfconnect-core) framework and
+This module is primarily used by the [nRF Connect](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher) framework and
 [nRF Device Setup]
 
 The following devices are supported:
@@ -26,7 +26,7 @@ $ npm install pc-nrf-dfu-js
 
 ##### Windows
 
-In order to access Nordic USB devices on Windows, specific device drivers must be installed. The device drivers are automatically installed by the nRF Connect installer, starting from version 2.4. The drivers can also be found [here](https://github.com/NordicSemiconductor/pc-nrfconnect-core/tree/master/build/drivers).
+In order to access Nordic USB devices on Windows, specific device drivers must be installed. The device drivers are automatically installed by the nRF Connect installer, starting from version 2.4. The drivers can also be found [here](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/tree/master/build/drivers).
 
 ##### Linux
 Linux requires correct permissions to access these devices. For this purpose please install udev rules from [nrf-udev](https://github.com/NordicSemiconductor/nrf-udev) repository, follow instructions there.

--- a/src/DfuError.js
+++ b/src/DfuError.js
@@ -128,7 +128,7 @@ export const ErrorMessages = {
     [ErrorCode.ERROR_CAN_NOT_INIT_PRN_TRANSPORT]: 'Cannot instantiate DfuTransportPrn, use a concrete subclass instead.',
     [ErrorCode.ERROR_CAN_NOT_USE_HIGHER_PRN]: 'DFU procotol cannot use a PRN higher than 0xFFFF.',
     [ErrorCode.ERROR_READ_CONFLICT]: 'DFU transport tried to read() while another read() was still waiting',
-    [ErrorCode.ERROR_TIMEOUT_READING_SERIAL]: 'Timeout while reading from serial transport. See https://github.com/NordicSemiconductor/pc-nrfconnect-core/blob/master/doc/serial-timeout-troubleshoot.md',
+    [ErrorCode.ERROR_TIMEOUT_READING_SERIAL]: 'Timeout while reading from serial transport. See https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/blob/master/doc/serial-timeout-troubleshoot.md',
     [ErrorCode.ERROR_RECEIVE_TWO_MESSAGES]: 'DFU transport received two messages at once',
     [ErrorCode.ERROR_RESPONSE_NOT_START_WITH_0x60]: 'Response from DFU target did not start with 0x60',
     [ErrorCode.ERROR_ASSERT_EMPTY_RESPONSE]: 'Tried to assert an empty parsed response',


### PR DESCRIPTION
This is part of [NCP-2704](https://projecttools.nordicsemi.no/jira/browse/NCP-2704).

The project `pc-nrfconnect-core` was renamed to `pc-nrfconnect-launcher`. This corrects references to the old name (links are redirected but it might still be confusing to keep on using the old name).