### PR TITLE
Upgrade serialport

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 `pc-nrf-dfu-js` is a Javascript module which provides DFU (Device Firmware Upgrade) via USB CDC ACM transport for Nordic devices.
 
 This module is primarily used by the [nRF Connect](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher) framework and
-[nRF Device Setup]
+[nRF Device Setup](https://github.com/NordicSemiconductor/nrf-device-setup-js).
 
 The following devices are supported:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrf-dfu-js",
-  "version": "0.2.10",
+  "version": "0.2.11",
   "description": "JS implementation of the nRF DFU protocol",
   "esnext:main": "src/index.js",
   "main": "dist/nrf-dfu.cjs.js",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint src/"
   },
   "peerDependencies": {
-    "serialport": "^7.1.5"
+    "serialport": "^8.0.7"
   },
   "devDependencies": {
     "debug": "^4.1.1",
@@ -22,17 +22,17 @@
     "eslint-plugin-import": "^2.18.0",
     "eslint-plugin-react": "^7.14.2",
     "jest": "^24.8.0",
-    "pc-nrfconnect-build": "git+https://github.com/NordicPlayground/pc-nrfconnect-build.git#semver:^0.0.1",
     "jest-bamboo-formatter": "1.0.1",
     "jest-serializer-path": "^0.1.15",
     "jszip": "^3.2.2",
+    "pc-nrfconnect-build": "git+https://github.com/NordicPlayground/pc-nrfconnect-build.git#semver:^0.0.1",
     "rollup": "^1.16.6",
     "rollup-plugin-commonjs": "^10.0.1",
     "rollup-plugin-eslint": "^7.0.0",
     "rollup-plugin-node-builtins": "^2.1.2",
     "rollup-plugin-node-globals": "^1.4.0",
     "rollup-plugin-node-resolve": "^5.2.0",
-    "serialport": "^7.1.5"
+    "serialport": "^8.0.7"
   },
   "jest": {
     "testMatch": [

--- a/src/DfuTransportUsbSerial.js
+++ b/src/DfuTransportUsbSerial.js
@@ -87,7 +87,7 @@ export default class DfuTransportUsbSerial extends DfuTransportSerial {
                     .then(ports => {
                         const port = ports.find(p => p.serialNumber === this.serialNumber);
                         if (port) {
-                            debug(`Found port ${port.comName} with serial number ${this.serialNumber}`);
+                            debug(`Found port ${port.path} with serial number ${this.serialNumber}`);
                             res(port);
                         } else if (retryCount < 50) {
                             retryCount += 1;
@@ -110,7 +110,7 @@ export default class DfuTransportUsbSerial extends DfuTransportSerial {
         }
         return this.findPort()
             .then(port => {
-                this.port = new SerialPort(port.comName, { baudRate: 115200, autoOpen: false });
+                this.port = new SerialPort(port.path, { baudRate: 115200, autoOpen: false });
                 return super.open();
             });
     }

--- a/test/util/common.js
+++ b/test/util/common.js
@@ -46,11 +46,11 @@ module.exports.findPort = async serialNumber => {
         const testPort = ports.find(p => p.serialNumber === serialNumber);
         if (testPort) {
             debug('Test serial port is found by serial number: ', serialNumber);
-            port = new SerialPort(testPort.comName, { baudRate: 115200, autoOpen: false });
+            port = new SerialPort(testPort.path, { baudRate: 115200, autoOpen: false });
         } else if (ports && ports[0]) {
             debug('Test serial port is not found by serial number: ', serialNumber);
             debug('Try to use the first found port.');
-            port = new SerialPort(ports[0].comName, { baudRate: 115200, autoOpen: false });
+            port = new SerialPort(ports[0].path, { baudRate: 115200, autoOpen: false });
         } else {
             throw new Error('No nordic serial device is available');
         }


### PR DESCRIPTION
Part of [NCP-2996](https://projecttools.nordicsemi.no/jira/browse/NCP-2996).

Upgrade serialport dependency to the latest version 8.0.7.

The new version has renamed the property `comName` to `path`.
