### PR TITLE
Set mtu to 20 to fix hash mismatch issue #44

### DIFF
--- a/src/DfuTransportNoble.js
+++ b/src/DfuTransportNoble.js
@@ -65,7 +65,7 @@ export default class DfuTransportNoble extends DfuTransportPrn {
         this.dfuPacketCharacteristic = undefined;
 
         // Hard-coded BLE MTU
-        this.mtu = 23;
+        this.mtu = 20;
     }
 
 


### PR DESCRIPTION
I think the main issue with noble as a transport is using a wrong MTU, the mtu setting in the code does not take into account the dfu protocol op codes that are prepended. Setting it from `23` to `20` allowed me to send and apply an application update. 

